### PR TITLE
Update writing-documentation.md

### DIFF
--- a/docs/writing-documentation.md
+++ b/docs/writing-documentation.md
@@ -31,7 +31,7 @@ brew install git
 
 Clone the repository to your local machine, using your favorite Git client or the command line:
 ```bash
-git lfs clone git@github.com:nuxeo/doc.nuxeo.com-content.git
+git clone git@github.com:nuxeo/doc.nuxeo.com-content.git
 cd doc.nuxeo.com-content
 git lfs install
 git reset --hard


### PR DESCRIPTION
change git lfs clone into git clone due to warning

```
git lfs clone git@github.com:nuxeo/doc.nuxeo.com-content.git
WARNING: 'git lfs clone' is deprecated and will not be updated
          with new flags from 'git clone'

'git clone' has been updated in upstream Git to have comparable
speeds to 'git lfs clone'.
```

Did not update it but editorconfig is unmaintained and failing for atom, not sure if we should reflect that
https://github.com/sindresorhus/atom-editorconfig#readme